### PR TITLE
Feature/add qubicj docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# Intellij IDE files
+.idea
+*.iml

--- a/docs/developers/client-qubicj-shell.md
+++ b/docs/developers/client-qubicj-shell.md
@@ -1,17 +1,19 @@
 ---
-title: Qubic Shell
+title: Qubic Java Shell
 ---
 
-# Qubic Shell (qubicj-shell)
+# Qubic Java Shell (qubicj-shell)
 
-The Qubic shell (`qubicj-shell` - a terminal and command line client and wallet) is an intermediate tool that allows
+The Qubic Java Shell (`qubicj-shell` - a terminal and command line client and wallet) is an intermediate tool that allows
 
 * to communicate with the Qubic Core nodes and 
 * provides wallet functionality.
 
 It uses and is part of the Qubic Java Library. You can get the code and the documentation here: 
 [Qubic Java repository](https://gitlab.com/georg.mittendorfer/qubicj) / 
-[Qubic Shell submodule](https://gitlab.com/georg.mittendorfer/qubicj/-/blob/main/qubicj-shell).
+[QubicJ Shell submodule](https://gitlab.com/georg.mittendorfer/qubicj/-/blob/main/qubicj-shell).
 
 The latest `qubicj-shell` release is always available here: 
 [Release Page](https://gitlab.com/georg.mittendorfer/qubicj/-/releases/permalink/latest).
+
+Qubicj is a community project.

--- a/docs/developers/client-qubicj-shell.md
+++ b/docs/developers/client-qubicj-shell.md
@@ -1,0 +1,17 @@
+---
+title: Qubic Shell
+---
+
+# Qubic Shell (qubicj-shell)
+
+The Qubic shell (`qubicj-shell` - a terminal and command line client and wallet) is an intermediate tool that allows
+
+* to communicate with the Qubic Core nodes and 
+* provides wallet functionality.
+
+It uses and is part of the Qubic Java Library. You can get the code and the documentation here: 
+[Qubic Java repository](https://gitlab.com/georg.mittendorfer/qubicj) / 
+[Qubic Shell submodule](https://gitlab.com/georg.mittendorfer/qubicj/-/blob/main/qubicj-shell).
+
+The latest `qubicj-shell` release is always available here: 
+[Release Page](https://gitlab.com/georg.mittendorfer/qubicj/-/releases/permalink/latest).

--- a/docs/developers/library-java.md
+++ b/docs/developers/library-java.md
@@ -1,0 +1,15 @@
+---
+title: Java Libraries
+---
+
+# Qubic Java Library (qubicj)
+
+The Qubic Java Library (`qubicj/qubicj-computor-api`) provides an API for developers to interact with the Qubic Network.
+
+It allows to quickly interact with the Qubic network without the need to 
+know the details of the Qubic network protocol and provides features like auto node selection.
+It can be used in classic or reactive stacks.
+
+For full documentation, please visit the [Qubic Java repository](https://gitlab.com/georg.mittendorfer/qubicj). 
+The [Qubic Shell submodule](https://gitlab.com/georg.mittendorfer/qubicj/-/blob/main/qubicj-shell) provides a demo on 
+how to use the library in a classic Java stack with Spring.

--- a/docs/developers/library-java.md
+++ b/docs/developers/library-java.md
@@ -11,5 +11,7 @@ know the details of the Qubic network protocol and provides features like auto n
 It can be used in classic or reactive stacks.
 
 For full documentation, please visit the [Qubic Java repository](https://gitlab.com/georg.mittendorfer/qubicj). 
-The [Qubic Shell submodule](https://gitlab.com/georg.mittendorfer/qubicj/-/blob/main/qubicj-shell) provides a demo on 
+The [qubicj-shell submodule](https://gitlab.com/georg.mittendorfer/qubicj/-/blob/main/qubicj-shell) provides a demo on 
 how to use the library in a classic Java stack with Spring.
+
+Qubicj is a community project.

--- a/sidebars.js
+++ b/sidebars.js
@@ -154,6 +154,7 @@ const sidebars = {
         'developers/library-typescript',
         'developers/qubic-node',
         'developers/qubic-cli',
+        'developers/client-qubicj-shell',
         'developers/library-go',
         'developers/library-http',
         'developers/library-csharp',
@@ -164,6 +165,7 @@ const sidebars = {
       label: 'Integration',
       items: [
         'developers/integration',
+        'developers/library-java',
       ],
     },
     {


### PR DESCRIPTION
Add page for Qubic Java Library (qubicj/qubicj-computor-api) to developers/integration section.
Add page for Qubic Shell (qubicj-shell) to developers/client section.