### PR TITLE
Update qubicj links

### DIFF
--- a/docs/developers/client-qubicj-shell.md
+++ b/docs/developers/client-qubicj-shell.md
@@ -10,10 +10,10 @@ The Qubic Java Shell (`qubicj-shell` - a terminal and command line client and wa
 * provides wallet functionality.
 
 It uses and is part of the Qubic Java Library. You can get the code and the documentation here: 
-[Qubic Java repository](https://gitlab.com/georg.mittendorfer/qubicj) / 
-[QubicJ Shell submodule](https://gitlab.com/georg.mittendorfer/qubicj/-/blob/main/qubicj-shell).
+[Qubic Java repository](https://gitlab.com/qubic-contributions/qubicj) / 
+[QubicJ Shell submodule](https://gitlab.com/qubic-contributions/qubicj/-/blob/main/qubicj-shell).
 
 The latest `qubicj-shell` release is always available here: 
-[Release Page](https://gitlab.com/georg.mittendorfer/qubicj/-/releases/permalink/latest).
+[Release Page](https://gitlab.com/qubic-contributions/qubicj/-/releases/permalink/latest).
 
 Qubicj is a community project.

--- a/docs/developers/library-java.md
+++ b/docs/developers/library-java.md
@@ -14,6 +14,6 @@ It allows to quickly interact with the Qubic network without the need to
 know the details of the Qubic network protocol and provides features like auto node selection.
 It can be used in classic or reactive stacks.
 
-For full documentation, please visit the [Qubic Java repository](https://gitlab.com/georg.mittendorfer/qubicj). 
-The [qubicj-shell submodule](https://gitlab.com/georg.mittendorfer/qubicj/-/blob/main/qubicj-shell) provides a demo on 
+For full documentation, please visit the [Qubic Java repository](https://gitlab.com/qubic-contributions/qubicj). 
+The [qubicj-shell submodule](https://gitlab.com/qubic-contributions/qubicj/-/blob/main/qubicj-shell) provides a demo on 
 how to use the library in a classic Java stack with Spring.


### PR DESCRIPTION
Update links because qubicj moved to another repository.