### PR TITLE
fix: add sidebar entry, cross-reference link, and typo fixes for cont…

### DIFF
--- a/docs/developers/smart-contracts/smart-contract/overview.md
+++ b/docs/developers/smart-contracts/smart-contract/overview.md
@@ -10,8 +10,6 @@ To isolate contracts, access to other contracts and Core internals is only allow
 
 A contract has a state struct, containing all its data as member variables. The memory available to the contract is allocated statically, but extending the state will be possible between epochs through special `EXPAND` events.
 
-**Contract developers should note that some parts of the Qubic protocol are not yet implemented.**
+**Important considerations for contract developers:**
 
-- Contract execution will eventually incur fees, paid from a fee reserve funded by QUs burned during the IPO and through ongoing burns. A contract must continue burning QUs to stay active—once the reserve is empty, it stops executing.
-
-- In the future, managing contracts will also need to pay for ledger entries, so collecting fees during asset issuance is recommended.
+- Contract execution incurs fees, paid from an execution fee reserve funded by QUs burned during the IPO and through ongoing burns. A contract must continue burning QUs to stay active—once the reserve is empty, it stops executing. See [Contract Execution Fees](/docs/learn/contract-execution-fees) for details.

--- a/docs/learn/contract-execution-fees.md
+++ b/docs/learn/contract-execution-fees.md
@@ -33,7 +33,7 @@ For details, please see [this developer documentation](https://github.com/qubic/
 ## Consolidating Fees Across Computors
 
 To ensure that the state of the Qubic network stays consistent across all nodes, each computor has to deduct the same execution fee amount for each contract.
-However, the actual execution time will vary due e.g. different hardware setups.
+However, the actual execution time will vary due to e.g. different hardware setups.
 To account for that, each computor can define their own multiplier to scale the raw execution time. 
 To consolidate the scaled execution times from each computor into a single consistent execution fee value, the so called *quorum value* is used:
 
@@ -48,7 +48,7 @@ After all transactions are sent, the received execution fee values are sorted in
 2. **Burn collected invocation rewards**: Regularly burn QUs to replenish the execution fee reserve.
 3. **Monitor reserve**: Implement a function to expose current reserve level.
 4. **Graceful degradation**: Consider what happens when reserve runs low.
-5. **Handle inter-contract call errors**: After calling procesdures of another contract, verify that the call succeeded. Handle errors gracefully (e.g., skip operations, use fallback logic). You can also proactively verify the called contract has positive fee reserve using the query function provided in QPI before calling.
+5. **Handle inter-contract call errors**: After calling procedures of another contract, verify that the call succeeded. Handle errors gracefully (e.g., skip operations, use fallback logic). You can also proactively verify the called contract has positive fee reserve using the query function provided in QPI before calling.
 
 ### For Contract Users
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -63,6 +63,7 @@ const sidebars = {
         "learn/smart-contracts",
         "learn/ipo",
         "learn/dutch-auction",
+        "learn/contract-execution-fees",
         "learn/qx",
         "learn/random",
         "learn/mlm",


### PR DESCRIPTION
…ract execution fees

- Add contract-execution-fees to Learn sidebar under "Smart Contracts and IPOs"
- Update developers overview.md with cross-reference link and fix outdated text
- Fix typos: "due e.g." → "due to e.g.", "procesdures" → "procedures"