### PR TITLE
chore: decode OpenAPI spec from dispatch payload

### DIFF
--- a/.github/workflows/update-api-docs.yml
+++ b/.github/workflows/update-api-docs.yml
@@ -20,30 +20,21 @@ permissions:
   pull-requests: write
 
 jobs:
-  update-live-api:
+  live-api-update:
     if: >
       github.event_name == 'repository_dispatch' && github.event.action == 'live-api-update' ||
       github.event_name == 'workflow_dispatch' && (github.event.inputs.api == 'live' || github.event.inputs.api == 'both')
     runs-on: ubuntu-latest
     concurrency:
-      group: update-live-api
+      group: live-api-update
       cancel-in-progress: true
     steps:
       - name: Checkout docs repo
         uses: actions/checkout@v4
 
-      - name: Checkout qubic-http
-        uses: actions/checkout@v4
-        with:
-          repository: qubic/qubic-http
-          path: tmp/qubic-http
-          sparse-checkout: |
-            protobuff/qubic.openapi.yaml
-
-      - name: Copy OpenAPI file and cleanup
+      - name: Decode Live API OpenAPI spec from payload
         run: |
-          cp tmp/qubic-http/protobuff/qubic.openapi.yaml static/openapi/qubic-http.openapi.yaml
-          rm -rf tmp/
+          echo "${{ github.event.client_payload.openapi_spec_base64 }}" | base64 -d > static/openapi/qubic-http.openapi.yaml
 
       - name: Check for changes
         id: changes
@@ -69,30 +60,21 @@ jobs:
           delete-branch: true
           labels: automated
 
-  update-query-api:
+  query-api-update:
     if: >
       github.event_name == 'repository_dispatch' && github.event.action == 'query-api-update' ||
       github.event_name == 'workflow_dispatch' && (github.event.inputs.api == 'query' || github.event.inputs.api == 'both')
     runs-on: ubuntu-latest
     concurrency:
-      group: update-query-api
+      group: query-api-update
       cancel-in-progress: true
     steps:
       - name: Checkout docs repo
         uses: actions/checkout@v4
 
-      - name: Checkout archive-query-service
-        uses: actions/checkout@v4
-        with:
-          repository: qubic/archive-query-service
-          path: tmp/archive-query-service
-          sparse-checkout: |
-            v2/api/archive-query-service/v2/query_services.openapi.yaml
-
-      - name: Copy OpenAPI file and cleanup
+      - name: Decode Query API OpenAPI spec from payload
         run: |
-          cp tmp/archive-query-service/v2/api/archive-query-service/v2/query_services.openapi.yaml static/openapi/query-services.openapi.yaml
-          rm -rf tmp/
+          echo "${{ github.event.client_payload.openapi_spec_base64 }}" | base64 -d > static/openapi/query-services.openapi.yaml
 
       - name: Check for changes
         id: changes


### PR DESCRIPTION
Update workflow to decode base64-encoded OpenAPI specs received via repository_dispatch payload instead of checking out source repos.