### PR TITLE
fix: limit Query API auto-PR to only the OpenAPI spec file

### DIFF
--- a/.github/workflows/update-api-docs.yml
+++ b/.github/workflows/update-api-docs.yml
@@ -129,3 +129,5 @@ jobs:
           branch: docs/update-query-api-spec
           delete-branch: true
           labels: automated
+          add-paths: |
+            static/openapi/query-services.openapi.yaml


### PR DESCRIPTION
Adds `add-paths` so `peter-evans/create-pull-request` only stages the spec yaml, preventing the nested `archive-query-service` checkout from being captured as a submodule gitlink (which broke Netlify deploy on PR #68).