### PR TITLE
ci: strip internal /health endpoint from Live API docs

### DIFF
--- a/.github/workflows/update-api-docs.yml
+++ b/.github/workflows/update-api-docs.yml
@@ -56,6 +56,14 @@ jobs:
           export PATH="$(go env GOPATH)/bin:$PATH"
           make openapi-v3
 
+      - name: Apply OpenAPI adjustments
+        working-directory: qubic-http/protobuff
+        run: |
+          # Remove the internal-only /health endpoint (upstream marks it
+          # "for internal use only ... Do not rely on this endpoint").
+          # --indent 4 matches the generator output so yq doesn't reflow the file.
+          yq -i --indent 4 'del(.paths."/health")' qubic.openapi.yaml
+
       - name: Copy spec into place
         run: cp qubic-http/protobuff/qubic.openapi.yaml static/openapi/qubic-http.openapi.yaml
 


### PR DESCRIPTION
The live-api-update job copied the qubic-http OpenAPI spec verbatim, so the upstream /health endpoint (marked "for internal use only ... Do not rely on this endpoint") would surface in the published docs.

Add an "Apply OpenAPI adjustments" step mirroring the query-api job, deleting the /health path with `yq --indent 4` (the indent flag keeps yq from reflowing the 4-space generator output to 2 spaces). The HealthResponse schema is intentionally left in place to match the query-api job; hideModels in the Scalar config keeps it hidden.