### PR TITLE
Fix typos and document NFT pattern in assets-and-shares example

### DIFF
--- a/docs/developers/smart-contracts/sc-by-examples/assets-and-shares.md
+++ b/docs/developers/smart-contracts/sc-by-examples/assets-and-shares.md
@@ -136,3 +136,20 @@ struct acquireShares_output {
 - Both contracts update their states
 
 - MYTEST's `PRE_RELEASE_SHARES` is invoked
+
+## NFTs and Unique Assets
+
+The same asset system can represent **non-fungible tokens (NFTs)**. By issuing assets with `numberOfShares = 1` and a unique `assetName` per token, each share becomes a distinct, non-fungible item:
+
+```
+// Issue a unique NFT asset (1 share only)
+qpi.issueAsset(
+    uniqueAssetName,  // Unique per token (e.g., "NFT0001")
+    issuerId,
+    0,                // No decimal places for NFTs
+    1,                // Single share = unique item
+    0                 // Unit of measurement (unused for NFTs)
+);
+```
+
+Each NFT's `assetName` acts as the token ID. Ownership and possession follow the same `transferShareOwnershipAndPossession()` pattern, and metadata (image, attributes) can be stored off-chain (IPFS) with the hash referenced in the contract state or emitted via a function.

--- a/docs/developers/smart-contracts/smart-contract/data-types.md
+++ b/docs/developers/smart-contracts/smart-contract/data-types.md
@@ -15,7 +15,7 @@ uint64 b = 10000000000;
 
 ## Booleans
 
-Booleans is resperent by `bit` data type
+Booleans are represented by the `bit` data type
 
 ```cpp
 bit isRight = true;

--- a/docs/learn/glossary.md
+++ b/docs/learn/glossary.md
@@ -46,10 +46,10 @@ A quorum is the minimum number of computors necessary to conduct any sort of bus
 Self-executing contracts with the terms of the agreement directly written into code. Qubic's first [smart contract](/learn/smart-contracts) was an Initial Public Offering ([IPO](/learn/ipo)) of 676 shares for a decentralized exchange (DEX) named [Qx](/learn/qx).
 
 ## Spectrum
-Qubic's equivalent of a ledger. In the [Spectrum](/learn/spectrum) the energy (i.e. QUs) per Identity is stored. Qubic itself does not not keep track of transactions.
+Qubic's equivalent of a ledger. In the [Spectrum](/learn/spectrum) the energy (i.e. QUs) per Identity is stored. Qubic itself does not keep track of transactions.
 
 ## Ticks
-In the Qubic ecosystem, the tick is the interval within which the Quorum commes to an agreement on transactions and the outcome computed smart contracts. A single tick can last a very short interval of time (below 1 second).
+In the Qubic ecosystem, the tick is the interval within which the Quorum comes to an agreement on transactions and the outcome computed smart contracts. A single tick can last a very short interval of time (below 1 second).
 
 ## Useful Proof of Work (UPoW)
 A novel consensus mechanism that optimizes the energy expended in mining processes by directing computational power towards valuable, real-world tasks, such as training artificial intelligence models. Unlike traditional Proof of Work systems that "waste" energy by solving abstract puzzles, [UPoW](/learn/upow) contributes to meaningful applications.


### PR DESCRIPTION
## Summary

Three small fixes + one documentation addition:

### Fixes
- `data-types.md`: "Booleans is resperent by" → "Booleans are represented by the"
- `glossary.md`: "does not not keep track" → "does not keep track"
- `glossary.md`: "commes to an agreement" → "comes to an agreement"

### Addition
- `assets-and-shares.md`: Added a section explaining how Qubic's native asset system (`qpi.issueAsset()` with `numberOfShares = 1`) can represent NFTs. Includes a code example and notes on metadata storage.

This fills a gap — the Qubic docs currently have zero references to NFTs despite the asset system supporting unique tokens.