### PR TITLE
docs: fix duplicated hook in assets-and-shares interaction flow

### DIFF
--- a/docs/developers/smart-contracts/sc-by-examples/assets-and-shares.md
+++ b/docs/developers/smart-contracts/sc-by-examples/assets-and-shares.md
@@ -135,7 +135,7 @@ struct acquireShares_output {
 
 - Both contracts update their states
 
-- MYTEST's `PRE_RELEASE_SHARES` is invoked
+- MYTEST's `POST_RELEASE_SHARES` is invoked
 
 ## NFTs and Unique Assets
 


### PR DESCRIPTION
The acquireShares interaction flow listed MYTEST's PRE_RELEASE_SHARES twice; the final post-transfer step should be POST_RELEASE_SHARES. Verified against core (qpi.acquireShares invokes the source contract's PRE_RELEASE_SHARES and POST_RELEASE_SHARES).