### PR TITLE
docs: update library docs for Qubic.NET and qubic-typescript

### DIFF
--- a/docs/developers/intro.md
+++ b/docs/developers/intro.md
@@ -45,8 +45,9 @@ If you want to build applications that interact with the Qubic network:
    - For complete wallet integration examples (MetaMask Snap, WalletConnect, Seed phrases, Vault files), check out the [HM25 Frontend Example](https://github.com/icyblob/hm25-frontend)
    - This repository demonstrates all key wallet connection methods
 
-3. **Use the TypeScript Library**
-   - The [Qubic TypeScript Library](https://github.com/qubic/ts-library) provides tools for creating transactions and interacting with the network
+3. **Use a TypeScript Library**
+   - [qubic-typescript](https://github.com/qubic/qubic-typescript) is the SDK to start with — transactions, RPC, live node subscriptions, typed contracts, and `@qubic.org/react` hooks, split into packages you install as needed (public beta)
+   - [ts-library](https://github.com/qubic/ts-library) is the older single-package library. Use it if you're maintaining a project built on it, or need the raw node protocol from a browser
    - See our [TypeScript Library docs](library-typescript.md) for installation instructions
 
 ### 3. Smart Contract Interaction
@@ -66,7 +67,8 @@ To interact with existing smart contracts:
 - **Set up development environment**: [Qubic Dev Kit](https://github.com/qubic/qubic-dev-kit)
 - **Core implementation**: [Qubic Core](https://github.com/qubic/core)
 - **Command line interaction**: [Qubic CLI](https://github.com/qubic/qubic-cli)
-- **TypeScript development**: [Qubic TypeScript Library](https://github.com/qubic/ts-library)
+- **TypeScript development**: [qubic-typescript SDK](https://github.com/qubic/qubic-typescript) or [Qubic TypeScript Library](https://github.com/qubic/ts-library)
+- **.NET development**: [Qubic.NET](https://github.com/qubic/Qubic.NET)
 - **Wallet management**: [Qubic Vault TypeScript Library](https://github.com/qubic/ts-vault-library)
 - **Frontend example**: [HM25 Frontend](https://github.com/icyblob/hm25-frontend)
 

--- a/docs/developers/library-csharp.md
+++ b/docs/developers/library-csharp.md
@@ -2,9 +2,12 @@
 title: C# Libraries
 ---
 
-# C# Library
+# C# Libraries
 
-The C# Qubic Library provides tools to interact with the Qubic Network.
+:::info[This page has moved]
+.NET library documentation now lives at **[.NET Libraries](./library-dotnet.md)**.
+:::
 
-For full documentation, please visit the [C# Qubic Library GitHub repository](https://github.com/qubic/qubic-csharp).
+C# developers can use [Qubic.NET](https://github.com/qubic/Qubic.NET), a modular .NET 8.0 library written in C# that covers node communication, transaction building and signing, and smart contract interaction. See [.NET Libraries](./library-dotnet.md) for packages, installation, and usage.
 
+The older [qubic-csharp](https://github.com/qubic/qubic-csharp) library is outdated and no longer maintained.

--- a/docs/developers/library-dotnet.md
+++ b/docs/developers/library-dotnet.md
@@ -1,0 +1,15 @@
+---
+title: .NET Libraries
+---
+
+# .NET Library
+
+## Qubic.NET
+
+[Qubic.NET](https://github.com/qubic/Qubic.NET) is a modular .NET 8.0 library for interacting with the Qubic network. It provides direct TCP node communication, HTTP RPC, and [Bob](https://github.com/qubic/core-bob) JSON-RPC clients, along with core domain models, binary serialization, and cryptographic primitives, split into packages you install as needed.
+
+For the package list, install instructions, and usage examples, see the [Qubic.NET README](https://github.com/qubic/Qubic.NET#readme).
+
+:::note
+The older [qubic-csharp](https://github.com/qubic/qubic-csharp) library is outdated and no longer maintained. New projects should use Qubic.NET.
+:::

--- a/docs/developers/library-typescript.md
+++ b/docs/developers/library-typescript.md
@@ -4,77 +4,25 @@ title: Typescript Libraries
 
 # Typescript Libraries
 
+Two TypeScript options exist. **Start with [qubic-typescript](#qubic-typescript-sdk)** — it covers everything the older [Qubic TypeScript Library](#qubic-typescript-library) does (identity and crypto helpers, transaction building, and direct TCP access to a node) and adds an RPC gateway client, a [Bob](https://github.com/qubic/core-bob) live-node client, typed contract wrappers, event decoding, and React hooks. It's split into focused packages, so you install only what you need.
+
+The Qubic TypeScript Library is still worth reaching for in two cases:
+
+- You're maintaining a project already built on it — it's stable and widely used.
+- You need the raw node protocol **from a browser**, which it reaches through qubic.li's WebSocket bridge. qubic-typescript's `@qubic.org/tcp` uses Node's `net` module, so it runs on Node and Bun but not in the browser.
+
+## qubic-typescript (SDK)
+
+[qubic-typescript](https://github.com/qubic/qubic-typescript) is a modular TypeScript SDK, split into focused packages for crypto, transaction building, RPC, ABI codec, live node subscriptions, and React integration. It is built for [Bun](https://bun.com) and works with Node.js.
+
+:::note
+qubic-typescript is in **public beta** — core APIs are stable and in production use, but the public surface has not frozen yet. Pin to an exact version and check the changelog when upgrading.
+:::
+
+For the package list, install instructions, dependency graph, and end-to-end examples, see the [qubic-typescript README](https://github.com/qubic/qubic-typescript#readme). For frontend work specifically, the [`@qubic.org/react`](https://github.com/qubic/qubic-typescript/tree/main/packages/react) package provides hooks and wallet providers out of the box.
+
 ## Qubic TypeScript Library
 
-The [Qubic TypeScript Library](https://github.com/qubic/ts-library) provides everything needed to interact with the Qubic network from JavaScript/TypeScript applications.
+The [Qubic TypeScript Library](https://github.com/qubic/ts-library) is the earlier single-package library for interacting with the Qubic network from JavaScript/TypeScript, covering identities, node connections, balances, transactions, and smart contract interaction. Its companion [Qubic Vault TypeScript Library](https://github.com/qubic/ts-vault-library) handles encrypted identity storage.
 
-### Installation
-
-```bash
-yarn add @qubic-lib/qubic-ts-library
-# or
-npm install @qubic-lib/qubic-ts-library
-```
-
-### Basic Usage
-
-```typescript
-// Import helper
-import { QubicHelper } from 'qubic-ts-library/dist/qubicHelper'
-import { QubicConnector } from 'qubic-ts-library/dist/qubicConnector'
-
-// Create helper instance
-const helper = new QubicHelper();
-
-// Create an ID Package from seed phrase
-const id = await helper.createIdPackage("your-seed-phrase");
-
-// Connect to a node
-const connector = new QubicConnector("https://rpc.qubic.org");
-
-// Get balance
-const balance = await connector.getBalance(id.publicId);
-```
-
-### Key Features
-
-- Creating and managing identities
-- Connecting to Qubic nodes
-- Fetching balances
-- Creating and signing transactions
-- Smart contract interaction
-
-For complete documentation and examples, visit:
-- [GitHub Repository](https://github.com/qubic/ts-library)
-- [Example Application](https://github.com/icyblob/hm25-frontend)
-
-## Vault TypeScript Library
-
-The [Qubic Vault TypeScript Library](https://github.com/qubic/ts-vault-library) provides tools for managing encrypted identity storage.
-
-### Installation
-
-```bash
-yarn add @qubic-lib/qubic-ts-vault-library
-# or
-npm install @qubic-lib/qubic-ts-vault-library
-```
-
-### Basic Usage
-
-```typescript
-import { QubicVault } from 'qubic-ts-vault-library/dist/qubicVault'
-
-// Create a new vault with password
-const vault = new QubicVault();
-vault.createVault("secure-password");
-
-// Add an identity to the vault
-vault.addIdentity("identity-name", "seed-phrase");
-
-// Export and save
-const vaultData = vault.exportVault();
-// Now save vaultData to file system
-```
-
-For complete vault library documentation, visit the [GitHub Repository](https://github.com/qubic/ts-vault-library).
+For installation and usage, see the [ts-library README](https://github.com/qubic/ts-library#readme) and the [ts-vault-library README](https://github.com/qubic/ts-vault-library#readme). The [HM25 frontend example](https://github.com/icyblob/hm25-frontend) shows both in a real application.

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,7 @@ Everything you need to start developing on Qubic:
 - [Typescript Libraries](developers/library-typescript): Libraries for Typescript development.
 - [Go Libraries](developers/library-go.md): Libraries for Go development.
 - [Http Libraries](developers/library-http.md): Libraries for HTTP-based development.
-- [C# Libraries](developers/library-csharp.md): Libraries for C# development.
+- [.NET Libraries](developers/library-dotnet.md): Libraries for .NET development.
 
 ## Development Programs
 - [Grants Program](developers/grants.md): Foster development of high-quality smart contracts and solutions.

--- a/sidebars.js
+++ b/sidebars.js
@@ -206,7 +206,7 @@ const sidebars = {
             "developers/library-java",
             "developers/library-go",
             "developers/library-http",
-            "developers/library-csharp",
+            "developers/library-dotnet",
             "developers/library-rust",
           ],
         },


### PR DESCRIPTION
Point .NET developers at Qubic.NET, which upstream marks as the successor to the outdated qubic-csharp. Rename the C# page to library-dotnet.md and leave library-csharp.md as an orphan stub that redirects old links to it.

Add the qubic-typescript SDK to the TypeScript page as the recommended starting point, with a comparison to ts-library covering when each still applies. Trim the copied package tables and code examples that duplicated the repo READMEs, replacing them with pointers to reduce drift.