### PR TITLE
docs: promote AIO Qubic Dev Kit as recommended SC setup path

### DIFF
--- a/docs/developers/intro.md
+++ b/docs/developers/intro.md
@@ -17,8 +17,9 @@ If you want to create and deploy smart contracts on Qubic:
    - Learn about IPO-based deployment and the advantages of running contracts without VMs or gas fees
 
 2. **Set Up Your Environment**
-   - Follow our [Development Environment Setup](dev-kit.md) guide for Visual Studio and Qubic Core
-   - Complete the [Getting Started Tutorial](smart-contracts/getting-started/setup-environment.md) for hands-on experience
+   - **Recommended:** [AIO Qubic Dev Kit](smart-contracts/getting-started/setup-environment.md#aio-qubic-dev-kit-linux--recommended) — Linux, Docker-based, one repo with Core + Faucet + Wallet + RPC bundled. Fastest path to a working local environment.
+   - Alternate (Windows/IDE): [Visual Studio + Qubic Core](smart-contracts/getting-started/setup-environment.md#visual-studio-windows--alternate).
+   - Then walk through the full [Getting Started tutorial](smart-contracts/getting-started/setup-environment.md).
 
 3. **Learn Contract Development**
    - Master the [Qubic Programming Interface (QPI)](qpi.md) - your complete guide to contract APIs

--- a/docs/developers/smart-contracts/getting-started/setup-environment.md
+++ b/docs/developers/smart-contracts/getting-started/setup-environment.md
@@ -4,13 +4,93 @@ sidebar_position: 1
 
 # Setup Environment
 
-To set up the environment for developing QUBIC smart contracts, you only need two things: `Visual Studio` and the [`Qubic Core`](https://github.com/qubic/core) repository. Simple, right?
+Pick the path that matches your machine — both get you a local Qubic environment you can develop smart contracts against.
+
+- **[AIO Qubic Dev Kit](#aio-qubic-dev-kit-linux--recommended)** — Linux, Docker-based, one repo, everything included. **This is the recommended path.**
+- **[Visual Studio](#visual-studio-windows--alternate)** — Windows / IDE workflow. Kept for teams already on this path.
+
+---
+
+## AIO Qubic Dev Kit (Linux — recommended)
+
+Clone one repo. Run it. You get a full local Qubic environment:
+
+- **Core** — local Qubic node
+- **Faucet** — funds test identities on demand
+- **Wallet** — user-side interactions with your contract
+- **RPC** — the same API surface your contract will hit in production
+
+Repo: [github.com/qubic/aio-qubic-dev-kit](https://github.com/qubic/aio-qubic-dev-kit)
+
+### Requirements
+
+This is a real dev environment, not a laptop toy:
+
+- **Linux x86-64 with AVX2** — Ubuntu 24.04 recommended
+- **≥24 GB RAM** — ≥32 GB for the full stack with the explorer
+- **8+ CPU cores** for the full stack
+- **~25–50 GB/day disk writes** at the default 1 s tick rate — provision generous disk headroom
+- **Tools:** `docker.io`, `docker-compose-v2`, `git`, `python3`, `make`, `g++`, `unzip`
 
 :::info
-We recommend to use [Qubic Core Lite](../resources/qubic-lite-core.md) repo instead of official Qubic Core so we can build and run the local testnet with our smart contract **directly in OS** without using VM to run the testnet.
+Not on Linux? Spin up a dev VPS (e.g. Hetzner, Contabo, Vultr) that meets the specs above. macOS and Windows are not supported for the AIO path — see the [Visual Studio](#visual-studio-windows--alternate) path below.
 :::
 
-## 1. Install Visual Studio
+### 1. Install prerequisites
+
+On a fresh Ubuntu 24.04 host:
+
+```bash
+sudo apt update
+sudo apt install -y docker.io docker-compose-v2 git python3 make g++ unzip
+```
+
+Add your user to the `docker` group so you don't need `sudo` for every command:
+
+```bash
+sudo usermod -aG docker $USER
+newgrp docker
+```
+
+### 2. Clone the repo
+
+```bash
+git clone https://github.com/qubic/aio-qubic-dev-kit
+cd aio-qubic-dev-kit
+```
+
+### 3. Run
+
+Follow the [repo README](https://github.com/qubic/aio-qubic-dev-kit) for the current start command and configuration knobs — it's the source of truth and moves faster than these docs.
+
+Once up, you have Core + Faucet + Wallet + RPC all running on localhost. Point your smart-contract test transactions at the local RPC and iterate freely.
+
+### 4. Verify it's working
+
+Check that the four services are reachable on the ports the README documents. If any fail to come up:
+
+```bash
+docker compose logs -f
+```
+
+### What's next
+
+- Continue to **[Add Your Contract](./add-your-contract.md)** — add a `.h` file to the Qubic Core source tree and wire it up.
+- Then **[Test Your Contract](./test-your-contract.md)** — write a test program and validate your contract locally.
+
+---
+
+## Visual Studio (Windows — alternate)
+
+Kept for teams already using the Visual Studio + Qubic Core workflow. Same end result — a local environment for smart-contract development — but Windows-native and IDE-driven.
+
+You'll need two things: `Visual Studio` and the [`Qubic Core`](https://github.com/qubic/core) repository.
+
+:::info
+For running a **local testnet** without a VM on Windows, use [Qubic Core Lite](../resources/qubic-lite-core.md) instead of the official Qubic Core.
+:::
+
+### 1. Install Visual Studio
 
 Go to [https://visualstudio.microsoft.com/](https://visualstudio.microsoft.com/) and click the `Download Visual Studio` button.
 
@@ -20,15 +100,15 @@ Once downloaded, open the `Visual Studio Installer`. Select the `Desktop develop
 
 ![VS](/img/install_vs3.png)
 
-Click the `Install` button. You’ll see a progress page — grab a coffee and wait for the installation to complete.
+Click the `Install` button. You'll see a progress page — grab a coffee and wait for the installation to complete.
 
 ![VS](/img/install_vs4.png)
 
-When the installation progess is completed, open the `Visual Studio`
+When the installation is complete, open `Visual Studio`.
 
 ![VS](/img/install_vs5.png)
 
-## 2. Clone the repo
+### 2. Clone the repo
 
 Choose `Clone a repository` and paste the following URL: `https://github.com/qubic/core.git`
 
@@ -38,11 +118,11 @@ Click the `Clone` button.
 
 ![VS](/img/install_vs7.png)
 
-Once the cloning is complete, double-click on `Qubic.sln` on the right-hand side to open the QUBIC solution.
+Once cloning is complete, double-click on `Qubic.sln` on the right-hand side to open the QUBIC solution.
 
 ![VS](/img/install_vs11.png)
 
-Now let’s test if everything is set up correctly by building the test project.  
+Now let's test if everything is set up correctly by building the test project.
 Right-click on the `test` project and select `Build`.
 
 ![VS](/img/install_vs8.png)
@@ -64,5 +144,5 @@ If you see logs like the one below — congrats! You've successfully set up your
 ![VS](/img/install_vs9.png)
 
 :::warning
-If you see the logs is The Windows SDK version xx.xx.xxxx.x was not found. Install the required version of Windows SDK or change the SDK version in the project property pages or by right-clicking the solution and selecting "Retarget solution".
+If the log says "The Windows SDK version xx.xx.xxxx.x was not found," install the required Windows SDK version or change the SDK version via the project property pages, or by right-clicking the solution and selecting "Retarget solution."
 :::

--- a/docs/developers/smart-contracts/overview.md
+++ b/docs/developers/smart-contracts/overview.md
@@ -5,6 +5,10 @@ sidebar_position: 1
 
 # QUBIC Smart Contract
 
+:::tip Ready to build?
+The fastest way to start developing a Qubic smart contract is the **[AIO Qubic Dev Kit](getting-started/setup-environment.md#aio-qubic-dev-kit-linux--recommended)** — one repo, Docker-based, includes Core + Faucet + Wallet + RPC. Continue with [Add Your Contract](getting-started/add-your-contract.md) once your environment is up.
+:::
+
 QUBIC smart contracts are decentralized `C++` programs that execute directly on baremetal hardware, eliminating the need for traditional operating systems or virtual machines. This low-level execution model provides high performance, low latency, and fine-grained control over computation. Unlike conventional blockchain platforms, QUBIC offers a unique architecture where contracts run closer to the hardware, ensuring deterministic and efficient execution across the network.
 
 Each smart contract can be launched through an IPO (Initial Public Offering), a mechanism that gathers community support and allocates computing resources to the contract. This system ensures that only valuable and trusted computations receive execution time, making QUBIC smart contracts efficient, scalable, and suitable for advanced decentralized applications.


### PR DESCRIPTION
The AIO Qubic Dev Kit (github.com/qubic/aio-qubic-dev-kit) went live on mainnet and is now the recommended way to develop smart contracts on Qubic. This adds it to the docs across three entry points.

Changes:
- developers/smart-contracts/getting-started/setup-environment.md: Restructured into two paths — AIO (Linux, recommended) and Visual Studio (Windows, alternate). AIO section covers requirements (Linux x86-64 + AVX2, >=24 GB RAM, 8+ cores, Docker + git + python3 + make + g++ + unzip), install prerequisites, clone, run, verify. Existing Windows / VS content preserved verbatim as the alternate path — no screenshots or steps lost, just demoted.

- developers/intro.md (Become a Developer): swapped the 'Set Up Your Environment' bullet from 'Visual Studio + Qubic Core' as the only option to AIO-first-with-Windows-as-alternate.

- developers/smart-contracts/overview.md: added a top-of-page ':::tip' callout pointing directly at the AIO section — a reader landing here from external links now has a one-click path to a working environment.

Timing: coordinates with the @QubicDev launch tweet (2026-08-04) announcing the AIO Dev Kit. Without this, that tweet would send devs to docs that still recommend Visual Studio.