### PR TITLE
docs: consolidate — AIO replaces the archived Qubic Dev Kit

### DIFF
--- a/docs/developers/dev-kit.md
+++ b/docs/developers/dev-kit.md
@@ -1,70 +1,56 @@
 ---
-title: Qubic Dev Kit
+title: AIO Qubic Dev Kit
 ---
 
-# Qubic Dev Kit
+# AIO Qubic Dev Kit
 
-The [Qubic Dev Kit](https://github.com/qubic/qubic-dev-kit) is your go-to tool for setting up a Qubic testnet node and running the HM25 Smart Contract demo for Hackathon Madrid 2025. It streamlines the process for developers looking to create and test their own smart contracts.
+The [**AIO Qubic Dev Kit**](https://github.com/qubic/aio-qubic-dev-kit) is the recommended tool for setting up a local Qubic development environment. Clone one repo, run `docker compose up`, and you get Core + Faucet + Wallet + RPC on localhost.
 
-## Important Notes
-
-- **Dev Kit Requirements**: Essential for developing and testing smart contracts, simulating the entire Qubic blockchain in a single environment. If you only need to interact with existing contracts, consider using the RPC API and wallet solutions instead.
-
-- **Support and Resources**: For any questions or if you need a server setup, please reach out in the #dev channel on our Discord. We may be able to provide server resources and assistance.
-
-## Overview
-
-The Dev Kit manages:
-- Complete Qubic development environment setup
-- EFI file building
-- Testnet node deployment with your smart contract
-- RPC access for testing
-
-## Development Environment Setup
-
-To set up the environment for developing QUBIC smart contracts, you need two main components: `Visual Studio` and the [`Qubic Core`](https://github.com/qubic/core) repository.
-
-:::info
-We recommend using [Qubic Core Lite](smart-contracts/resources/qubic-lite-core.md) repo instead of the official Qubic Core so you can build and run the local testnet with your smart contract **directly in OS** without using a VM.
+:::info Replaces the older Qubic Dev Kit
+The earlier [`qubic/qubic-dev-kit`](https://github.com/qubic/qubic-dev-kit) — built for Hackathon Madrid 2025 — was **archived by the maintainers on 2026-07-22**. Its README now redirects to AIO. If you're following an older guide that pointed at it, use AIO instead.
 :::
 
-### 1. Install Visual Studio
+## What's in the box
 
-1. Go to [https://visualstudio.microsoft.com/](https://visualstudio.microsoft.com/) and download Visual Studio
-2. Open the Visual Studio Installer and select the `Desktop development with C++` workload
-3. Complete the installation process
+- **Core** — local Qubic node
+- **Faucet** — funds test identities on demand
+- **Wallet** — user-side interactions with your contract
+- **RPC** — the same API surface your contract will hit in production
 
-### 2. Clone and Setup the Repository
+Everything you need to build, deploy, and iterate on a smart contract locally — without touching mainnet.
 
-1. Choose `Clone a repository` in Visual Studio
-2. Paste the URL: `https://github.com/qubic/core.git`
-3. Once cloned, open `Qubic.sln` from the solution explorer
-4. Test your setup by right-clicking the `test` project and selecting `Build`
+## Requirements
 
-If you see successful build logs, congratulations! Your development environment is ready.
+This is a real dev environment, not a laptop toy:
 
-## Getting Started with Dev Kit
+- **Linux x86-64 with AVX2** — Ubuntu 24.04 recommended
+- **≥24 GB RAM** — ≥32 GB for the full stack with the explorer
+- **8+ CPU cores** for the full stack
+- **~25–50 GB/day disk writes** at the default 1 s tick rate — provision generous disk headroom
+- **Tools:** `docker.io`, `docker-compose-v2`, `git`, `python3`, `make`, `g++`, `unzip`
 
-For complete documentation and setup instructions, check out the Dev Kit on GitHub: [Qubic Dev Kit](https://github.com/qubic/qubic-dev-kit)
+Not on Linux? Spin up a dev VPS (Hetzner / Contabo / Vultr / etc.) meeting the specs above. macOS and Windows are not supported for the AIO path — see the [Visual Studio alternate](smart-contracts/getting-started/setup-environment.md#visual-studio-windows--alternate) for the IDE workflow.
 
-The Dev Kit provides a streamlined workflow for:
-- Setting up a complete development environment
-- Building and testing smart contracts locally
-- Deploying to testnet for integration testing
+## Get started
 
-## Key Features
+```bash
+sudo apt install -y docker.io docker-compose-v2 git python3 make g++ unzip
+git clone https://github.com/qubic/aio-qubic-dev-kit
+cd aio-qubic-dev-kit
+# then follow the repo README for the current start command
+```
 
-- **Optimized for Demo Branch**: The Dev Kit works with the `madrid-2025` branch of the Qubic core repository
-- **Built-in Smart Contract Template**: Includes the HM25 template smart contract with Echo and Burn functions
-- **One-Command Deployment**: Deploy a complete node with your smart contract using a single command
-- **Local Testing Environment**: Run a complete Qubic testnet locally for development and testing
+Full step-by-step: **[Getting Started → Setup Environment](smart-contracts/getting-started/setup-environment.md#aio-qubic-dev-kit-linux--recommended)**.
 
-## Next Steps
+## Support
 
-After setting up your environment:
+Questions or setup issues? Reach out in the `#dev` channel on our Discord — the QCT team can help.
 
-1. **Learn Smart Contract Structure**: Check out our [Smart Contract Overview](smart-contracts/overview.md)
-2. **Follow the Getting Started Guide**: Complete the [Getting Started Tutorial](smart-contracts/getting-started/setup-environment.md)
-3. **Understand QPI**: Read about the [Qubic Programming Interface](qpi.md)
-4. **Explore Examples**: Look at [Smart Contract Examples](smart-contracts/sc-by-examples/assets-and-shares.md)
+## Next steps
 
+Once your environment is up:
+
+1. **Learn contract structure** — [Smart Contract Overview](smart-contracts/overview.md)
+2. **Walk through a full example** — [Getting Started Tutorial](smart-contracts/getting-started/setup-environment.md)
+3. **Understand the QPI** — [Qubic Programming Interface](qpi.md)
+4. **Study working contracts** — [Smart Contract Examples](smart-contracts/sc-by-examples/assets-and-shares.md)

--- a/docs/developers/intro.md
+++ b/docs/developers/intro.md
@@ -65,7 +65,7 @@ To interact with existing smart contracts:
 
 ## Quick Reference Links
 
-- **Set up development environment**: [Qubic Dev Kit](https://github.com/qubic/qubic-dev-kit)
+- **Set up development environment**: [AIO Qubic Dev Kit](https://github.com/qubic/aio-qubic-dev-kit)
 - **Core implementation**: [Qubic Core](https://github.com/qubic/core)
 - **Command line interaction**: [Qubic CLI](https://github.com/qubic/qubic-cli)
 - **TypeScript development**: [qubic-typescript SDK](https://github.com/qubic/qubic-typescript) or [Qubic TypeScript Library](https://github.com/qubic/ts-library)

--- a/docs/developers/smart-contracts/lifecycle.md
+++ b/docs/developers/smart-contracts/lifecycle.md
@@ -139,9 +139,9 @@ Every contract must be thoroughly tested using the GoogleTest (GTest) framework.
 
 Test your contract in a realistic network environment.
 
-- **Recommended**: Use [Qubic Core Lite](resources/qubic-lite-core.md) to run a local testnet directly on your OS — no VM needed
-- Alternatively, set up a [full testnet with VirtualBox](testing/testnet.md)
-- The [Qubic Dev Kit](https://github.com/qubic/qubic-dev-kit) can streamline the process
+- **Recommended**: Use the [AIO Qubic Dev Kit](../dev-kit.md) — Docker-based Linux environment with Core + Faucet + Wallet + RPC bundled
+- Alternate: [Qubic Core Lite](resources/qubic-lite-core.md) for running a local testnet directly on your OS without a VM
+- Or a [full testnet with VirtualBox](testing/testnet.md) for the traditional path
 - Monitor contract execution across multiple ticks
 - Test multi-node behavior to verify determinism
 

--- a/docs/developers/smart-contracts/rpc/setup-rpc.md
+++ b/docs/developers/smart-contracts/rpc/setup-rpc.md
@@ -73,4 +73,4 @@ https://github.com/KavataK/QubicNetworkDeploymentGuide
 
 https://github.com/KavataK/qubic-node-setup
 
-https://github.com/qubic/qubic-dev-kit
+https://github.com/qubic/aio-qubic-dev-kit

--- a/docs/developers/smart-contracts/testing/testnet.md
+++ b/docs/developers/smart-contracts/testing/testnet.md
@@ -313,4 +313,4 @@ https://github.com/KavataK/QubicNetworkDeploymentGuide
 
 https://github.com/KavataK/qubic-node-setup
 
-https://github.com/qubic/qubic-dev-kit
+https://github.com/qubic/aio-qubic-dev-kit

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,7 +42,7 @@ Expand your knowledge of the Qubic platform:
 Everything you need to start developing on Qubic:
 
 - [Become a Developer](developers/intro.md): Your starting guide to navigate Qubic development resources.
-- [Qubic Dev Kit](developers/dev-kit.md): Set up your local testnet and deploy smart contracts.
+- [AIO Qubic Dev Kit](developers/dev-kit.md): Set up your local Qubic environment (Core + Faucet + Wallet + RPC) and deploy smart contracts.
 - [Testnet Resources](developers/testnet-resources.md): Access faucets and test seeds for development.
 
 ## Tutorials


### PR DESCRIPTION
Upstream qubic/qubic-dev-kit was archived by the maintainers on 2026-07-22 and its README now redirects to aio-qubic-dev-kit. Consolidating our docs to match.

- developers/dev-kit.md: rewritten in place. Same URL (kept for existing external links) but content is now the AIO Qubic Dev Kit — what's in the box, requirements, quick-start commands, link to the full tutorial. Sidebar title updated to 'AIO Qubic Dev Kit'. Explicit ':::info' callout at the top acknowledging the older Qubic Dev Kit as archived (2026-07-22) so anyone landing here from an older link gets the transition notice.

- developers/intro.md: two dev-kit references swept.
  - 'Set Up Your Environment' bullet already pointed at AIO (previous commit).
  - 'Quick Reference Links' updated: 'Qubic Dev Kit' -> 'AIO Qubic Dev Kit'.

- docs/index.md (landing): 'Qubic Dev Kit' -> 'AIO Qubic Dev Kit' with updated description.

- smart-contracts/lifecycle.md 'Local Testing' section: reordered to lead with AIO ('Recommended'), Qubic Core Lite as 'Alternate', VirtualBox as 'the traditional path'. Old link to qubic-dev-kit removed.

- smart-contracts/rpc/setup-rpc.md and smart-contracts/testing/testnet.md reference lists: URL swapped from qubic-dev-kit -> aio-qubic-dev-kit.

All external links to /developers/dev-kit still resolve — no URL breaks.